### PR TITLE
Add support for negative numbers to table barchart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 .tmp
+bower_components

--- a/src/renderers/table.coffee
+++ b/src/renderers/table.coffee
@@ -210,20 +210,37 @@ $.fn.barchart =  ->
 
     values = []
     forEachCell (x) -> values.push x
+    # set max and min values
     max = Math.max(values...)
-    scaler = (x) -> 100*x/(1.4*max)
+    min = Math.min(values...)
+
+    # set bound to 0 if either all positive or all negative
+    max = 0 if max < 0
+    min = 0 if min > 0
+
+    # send back what percentage of the range the number is, and whether it is positive or negative
+    scaler = (x) ->
+      value: Math.abs(x)/(max-min)*100
+      positive: x > 0
+
+    # find the height percentage of the most negative number
+    bottom = if min is 0 then min else scaler(min).value
+
     forEachCell (x, elem) ->
       text = elem.text()
       wrapper = $("<div>").css
         "position": "relative"
         "height": "55px"
+
+      cell = scaler(x)
       wrapper.append $("<div>").css
         "position": "absolute"
-        "bottom": 0
         "left": 0
         "right": 0
-        "height": scaler(x) + "%"
-        "background-color": "gray"
+        "height": "#{cell.value}%"
+        "bottom": if cell.positive then "#{bottom}%" else "#{bottom-cell.value}%"
+        "background-color": if cell.positive then "#AAA" else "#DE2222"
+
       wrapper.append $("<div>").text(text).css
         "position":"relative"
         "padding-left":"5px"


### PR DESCRIPTION
Here is a short preview of what is changed.
![preview of changes](https://s3.amazonaws.com/f.cl.ly/items/0T2B3m0n3c2v2o3F2h2U/Image%202015-01-20%20at%202.14.49%20PM.png)

- The height is now a percentage of the range. `abs(n) / range * 100`
- X axis of 0 starts at the height lowest number in the set, defaulting to 0 if all numbers in the set are positive
- Negative numbers are red, and are positioned to drop below 0

On this image are examples for what will happen in these various cases:
- Only positive numbers = PROMOTIONAL row
- Only negative numbers = WEB row
- Both positive and negative numbers = all others
