### PR TITLE
Tweak the color of the negative barchart

### DIFF
--- a/src/renderers/table.coffee
+++ b/src/renderers/table.coffee
@@ -239,7 +239,7 @@ $.fn.barchart =  ->
         "right": 0
         "height": "#{cell.value}%"
         "bottom": if cell.positive then "#{bottom}%" else "#{bottom-cell.value}%"
-        "background-color": if cell.positive then "#AAA" else "#DE2222"
+        "background-color": if cell.positive then "#AAA" else "#FF4B4B"
 
       wrapper.append $("<div>").text(text).css
         "position":"relative"


### PR DESCRIPTION
Maksim wanted it more like the initial pass at coloring, so I tried to get a color as close to that one as possible while still remaining contrasting enough to both the values and positive number bars.

The color is still distinct enough that any type of color-blindness should be able to identify both.
Here's an example: http://cl.ly/image/0q1p2R093x3S